### PR TITLE
fixed the time count error

### DIFF
--- a/extension/js/content_script.js
+++ b/extension/js/content_script.js
@@ -42,6 +42,15 @@ var TimeCalculate = /** @class */ (function () {
     TimeCalculate.prototype.startTimerCounter = function () {
         var _this = this;
         this.startTime = this.timeOrphan;
+        var i;
+        chrome.storage.local.get('mainMemory', function (details) {
+            var allUrls = details.mainMemory.allUrls;
+            for (i = 0; i < allUrls.length; i++) {
+                if (allUrls[i].url == _this.URL) {
+                    _this.totalTime = allUrls[i].time;
+                }
+            }
+        });
         setInterval(function () {
             _this.totalTime += _this.calculate();
             var objectDOM = {

--- a/extension/tsc__/_ts_files/content_script.ts
+++ b/extension/tsc__/_ts_files/content_script.ts
@@ -58,7 +58,16 @@ class TimeCalculate  {
     }
 
     startTimerCounter() {	
-        this.startTime = this.timeOrphan;	
+        this.startTime = this.timeOrphan;
+        let i;	
+        chrome.storage.local.get('mainMemory', (details) => {
+            let allUrls = details.mainMemory.allUrls;
+            for(i=0; i<allUrls.length; i++){
+                if(allUrls[i].url == this.URL){
+                    this.totalTime = allUrls[i].time;
+                }
+            }
+        });
         setInterval(() => {	
             this.totalTime += this.calculate();	
             let objectDOM = {	


### PR DESCRIPTION
#20 
Fixed the time count error, now the time viewed of a particular website will be the total time for which the website was used including the earlier details. The time counts won't start from 0 again on refreshing a website.